### PR TITLE
Fixed 6 wire case when there are more then one yellow wires

### DIFF
--- a/source/assets/javascripts/components/mod/_mod.wires.js
+++ b/source/assets/javascripts/components/mod/_mod.wires.js
@@ -102,7 +102,7 @@ function solveWires(wires) {
 
       // If there is exactly one yellow wire and there is more than one white wire, cut the fourth wire.
       else if (wires.indexOf('yellow') > -1 &&
-          checkForDuplicateValues(wires).indexOf('yellow') &&
+          checkForDuplicateValues(wires).indexOf('yellow') == -1 &&
           checkForDuplicateValues(wires).indexOf('white') > -1) {
         return 'Cut the fourth wire!';
       }


### PR DESCRIPTION
When there where more than one yellow wire in the 6 wire case, the if for cutting the fourth wire could be falsely triggered.

Example:
White - Yellow - White - Yellow - Black - Yellow
Correct: Last wire