### PR TITLE
Update Maze URL

### DIFF
--- a/source/shared/mods/_mod.maze.slim
+++ b/source/shared/mods/_mod.maze.slim
@@ -8,7 +8,7 @@
 
       .mod-maze.js-maze
         - for k in (0..8)
-          = image_tag "http://www.bombmanual.com/manual/1/html/img/gen/maze/maze#{k}.svg", class: "mod-maze__maps js-maze-map js-maze-index-#{k}"
+          = image_tag "http://www.bombmanual.com/web/img/modules/maze/maze#{k}.svg", class: "mod-maze__maps js-maze-map js-maze-index-#{k}"
 
         .js-maze-map-container
           - for i in (1..6)


### PR DESCRIPTION
The maze appears to have changed from the format of 
https://www.bombmanual.com/manual/1/html/img/gen/maze/maze3.svg to
https://www.bombmanual.com/web/img/modules/maze/maze3.svg.

Updated to my eye, I do not know the language used here personally.